### PR TITLE
feat: Implement replay buffer, add replay config options

### DIFF
--- a/skyrl-train/examples/async/async_trainer.py
+++ b/skyrl-train/examples/async/async_trainer.py
@@ -140,12 +140,7 @@ class AsyncRayPPOTrainer(RayPPOTrainer):
 
     async def _run_training(self, generation_buffer):
         # Get a generation future and await on the object
-        item = await generation_buffer.get()
-        if isinstance(item, tuple) and len(item) == 3:
-            generator_output, uids, behavior_version = item  # GeneratorOutput, List[str], int
-        else:
-            generator_output, uids = item  # fallback for backward compatibility
-            behavior_version = self.policy_version
+        generator_output, uids, behavior_version = await generation_buffer.get()  # GeneratorOutput, List[str], int
 
         # print example just for debugging
         vis = self.tokenizer.decode(generator_output["response_ids"][0])

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -106,6 +106,11 @@ trainer:
       type: null # filter, replace, or null
       max_sample_batches: 30 # sample at most this many batches before stopping, -1 to sample forever
       min_replace_ratio: 0.3 # minimum proportion of good samples with which to replace bad samples (for replace strategy only)
+  off_policy:
+    enable: false # whether to enable or disable off-policy training
+    buffer_capacity: 64    # optional, if you add replay
+    max_staleness_steps: 1    # 0 = strictly on-policy, >=1 = off-policy
+    prefer_recent: true       # optional, bias sampler to fresher item
 
   gradient_checkpointing: true
   gradient_checkpointing_use_reentrant: false

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -107,11 +107,12 @@ trainer:
       type: null # filter, replace, or null
       max_sample_batches: 30 # sample at most this many batches before stopping, -1 to sample forever
       min_replace_ratio: 0.3 # minimum proportion of good samples with which to replace bad samples (for replace strategy only)
-  off_policy:
-    enable: false # whether to enable or disable off-policy training
-    buffer_capacity: 64    # optional, if you add replay
-    max_staleness_steps: 1    # 0 = strictly on-policy, >=1 = off-policy
-    prefer_recent: true       # optional, bias sampler to fresher item
+  replay:
+    enable: false                # enable/disable replay layer
+    buffer_capacity: 64          # number of items (trajectories) to retain in replay
+    sample_batch_size: 1024      # trajectories per training sample from replay
+    max_staleness_steps: 1       # 0=strictly on-policy; >=1 allows bounded off-policy
+    sampling: prefer_recent      # prefer_recent | fifo | random
 
   gradient_checkpointing: true
   gradient_checkpointing_use_reentrant: false

--- a/skyrl-train/skyrl_train/dataset/replay_manager.py
+++ b/skyrl-train/skyrl_train/dataset/replay_manager.py
@@ -1,0 +1,110 @@
+from typing import List, Optional
+
+import torch
+
+from skyrl_train.training_batch import TrainingInputBatch
+from skyrl_train.dataset.replay_buffer import (
+    Experience,
+    NaiveReplayBuffer,
+    make_experience_batch,
+)
+
+
+class TrainingBatchReplay:
+    """
+    Replay manager that stores trajectory-level items (BufferItem) by
+    wrapping NaiveReplayBuffer, and exposes simple batch append/sample APIs.
+
+    - Append: converts a TrainingInputBatch into an Experience, tags behavior_version
+      per-sample, and appends (with eviction via NaiveReplayBuffer.limit).
+    - Sample: filters items by staleness, then samples indices according to policy,
+      collates back to an Experience and converts to TrainingInputBatch.
+    """
+
+    def __init__(self, sample_batch_size: int, capacity: int, cpu_offload: bool = True) -> None:
+        self.sample_batch_size = sample_batch_size
+        self.buffer = NaiveReplayBuffer(
+            sample_batch_size=sample_batch_size,
+            limit=capacity,
+            cpu_offload=cpu_offload,
+        )
+
+    @staticmethod
+    def _batch_to_experience(batch: TrainingInputBatch, behavior_version: int) -> Experience:
+        batch_size = batch.batch_size
+        info = {
+            # tensor so split_experience_batch can propagate per-item
+            "behavior_version": torch.full((batch_size,), behavior_version, dtype=torch.int32),
+        }
+        exp = Experience(
+            sequences=batch["sequences"],
+            action_log_probs=batch.get("action_log_probs"),
+            base_action_log_probs=batch.get("base_action_log_probs"),
+            values=batch.get("values"),
+            returns=batch.get("returns"),
+            advantages=batch.get("advantages"),
+            attention_mask=batch.get("attention_mask"),
+            loss_mask=batch.get("loss_mask"),
+            action_mask=batch.get("response_mask"),
+            num_actions=int(batch.metadata["response_length"]),
+            info=info,
+            metadata=batch.metadata,
+        )
+        return exp
+
+    @staticmethod
+    def _experience_to_batch(exp: Experience) -> TrainingInputBatch:
+        batch = TrainingInputBatch(
+            {
+                "sequences": exp.sequences,
+                "attention_mask": exp.attention_mask,
+                "response_mask": exp.action_mask,
+                "loss_mask": exp.loss_mask,
+                "action_log_probs": exp.action_log_probs,
+                "base_action_log_probs": exp.base_action_log_probs,
+                "values": exp.values,
+                "returns": exp.returns,
+                "advantages": exp.advantages,
+            }
+        )
+        batch.metadata = exp.metadata if exp.metadata is not None else {}
+        return batch
+
+    def append(self, batch: TrainingInputBatch, behavior_version: int) -> None:
+        exp = self._batch_to_experience(batch, behavior_version)
+        self.buffer.append(exp)
+
+    def sample(
+        self,
+        current_policy_version: int,
+        max_staleness_steps: int,
+        sampling: str = "prefer_recent",
+        sample_batch_size: Optional[int] = None,
+    ) -> Optional[TrainingInputBatch]:
+        if len(self.buffer) == 0:
+            return None
+
+        # Filter by staleness bound
+        candidates = []
+        for it in self.buffer.items:
+            bv = int(it.info.get("behavior_version", 0)) if it.info is not None else 0
+            if current_policy_version - bv <= max_staleness_steps:
+                candidates.append(it)
+
+        if not candidates:
+            return None
+
+        k = sample_batch_size or self.sample_batch_size
+        if sampling == "fifo":
+            picked = candidates[:k]
+        elif sampling == "random":
+            # torch.random for deterministic control if needed
+            idx = torch.randperm(len(candidates))[:k].tolist()
+            picked = [candidates[i] for i in idx]
+        else:  # prefer_recent
+            picked = candidates[-k:]
+
+        exp = make_experience_batch(picked)
+        return self._experience_to_batch(exp)
+
+

--- a/skyrl-train/skyrl_train/dataset/replay_manager.py
+++ b/skyrl-train/skyrl_train/dataset/replay_manager.py
@@ -98,7 +98,7 @@ class TrainingBatchReplay:
         if sampling == "fifo":
             picked = candidates[:k]
         elif sampling == "random":
-            # torch.random for deterministic control if needed
+            # torch.random for determinism based on seed
             idx = torch.randperm(len(candidates))[:k].tolist()
             picked = [candidates[i] for i in idx]
         else:  # prefer_recent


### PR DESCRIPTION
- Implements a `TrainingBatchReplay` that enables replay sampling with staleness filtering.
- Adds replay config options (replay buffer size, sampling policy, max_staleness, etc.)
- Enables `TrainingBatchReplay` behind config option flag in the async trainer.